### PR TITLE
Skip blanklines in jupyter-info directive

### DIFF
--- a/book_source/source/ext/custom_directives.py
+++ b/book_source/source/ext/custom_directives.py
@@ -40,7 +40,7 @@ class DataDownloadLinks(SphinxDirective):
 
         new_content = (
             self.prefix_content()
-            + [self.download_prefix() + line for line in self.content]
+            + [self.download_prefix() + line for line in self.content if line]
             + self.postfix_content()
         )
 


### PR DESCRIPTION
Caused weird formatting with jupyter-info that had no datasets.

Closes #33