### PR TITLE
Fix base64 encoding of Trace files

### DIFF
--- a/book_source/source/ext/custom_directives.py
+++ b/book_source/source/ext/custom_directives.py
@@ -2,6 +2,7 @@ import base64
 import json
 from logging import debug
 from trace import Trace
+import urllib.parse
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
@@ -32,7 +33,7 @@ def create_trace_files_param(code):
             }
         ],
     }
-    return base64.urlsafe_b64encode(json.dumps(payload).encode()).decode()
+    return urllib.parse.quote(base64.standard_b64encode(json.dumps(payload).encode()).decode())
 
 
 class TraceSnippet(SphinxDirective):


### PR DESCRIPTION
Generating Trace urls is broken in some cases!

**Cause:** I was using Python's urlsafe_b64encode which uses a non-standard (but URL safe) alphabet to encode the files, but JavaScript doesn't have a built-in decoder that understands that alphabet.

**Fix:** use standard_b64encode instead of urlsafe_b64encode, and then use standard URL encoding when constructing the URL. On the JS side, we can use built-ins to (1) URL decode to get the base64 and then (2) decode the base64 using the standard alphabet.