### PR TITLE
Update URL for Trace embed script

### DIFF
--- a/book_source/source/_templates/layout.html
+++ b/book_source/source/_templates/layout.html
@@ -4,7 +4,7 @@
     {{ super() }}
 
     <!-- Add trace snippet -->
-    <script src="https://learnwithtrace.com/some-embed-script.js"></script>
+    <script src="https://trace-scripts.s3.amazonaws.com/trace-embed-v1.js"></script>
 
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-571NY3SGCX"></script>

--- a/book_source/source/ext/snippet-template.html
+++ b/book_source/source/ext/snippet-template.html
@@ -1,5 +1,5 @@
 <div class="trace-snippet-container">
-    <div data-trace-payload="files={params}&language=PYTHON&hideReadonlyFiles=true">
+    <div data-trace-payload="files={params}&language=PYTHON&hideReadonlyFiles=true&autosubmit=true&autoplay=true">
         <div class="highlight-python">
             <div class="highlight">
                 <pre>{code}</pre>


### PR DESCRIPTION
@hschafer, I have an update! Current approach is to render a "Run" button beneath the snippet - when clicked, it replaces the snippet with the Trace iframe.

<img width="1792" alt="Screen Shot 2022-01-19 at 9 11 36 PM" src="https://user-images.githubusercontent.com/8902272/150281921-f25cbe22-20e9-4057-9c95-a28e5c22a978.png">

Let me know your thoughts!
